### PR TITLE
Explore using multiclass & defm to simplify lowering.

### DIFF
--- a/include/npcomp/Dialect/RD/IR/RDDatasetInterface.h
+++ b/include/npcomp/Dialect/RD/IR/RDDatasetInterface.h
@@ -9,7 +9,8 @@
 #ifndef NPCOMP_DIALECT_RD_IR_RDDATASETINTERFACE_H
 #define NPCOMP_DIALECT_RD_IR_RDDATASETINTERFACE_H
 
-#include "mlir/IR/Types.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 
 namespace mlir {

--- a/include/npcomp/Dialect/RD/IR/RDDatasetInterface.td
+++ b/include/npcomp/Dialect/RD/IR/RDDatasetInterface.td
@@ -25,7 +25,39 @@ def DatasetTransformOpInterface : OpInterface<"DatasetTransform"> {
     InterfaceMethod<[{
       Builds initialization code given a pointer to the type returned by buildStateLLVMType.
     }],
-    "void", "buildInitState", (ins "OpBuilder &":$builder, "Value":$ptr, "const rd::InitArgMap &":$args)>
+    "void", "buildInitState", (ins "OpBuilder &":$builder, "Value":$ptr, "const rd::InitArgMap &":$args)>,
+    InterfaceMethod<[{
+      Description
+    }], "void", "buildNextOp",
+    (ins "OpBuilder&":$builder, "BlockAndValueMapping &":$mapping, "Value":$iterator)>
+  ];
+}
+
+def DatasetInitOpInterface : OpInterface<"DatasetInit"> {
+  let description = [{
+    Properties of dataset init ops; used for lowering.
+  }];
+  let cppNamespace = "::mlir::NPCOMP::rd";
+
+  let methods = [
+    InterfaceMethod<[{
+      Returns the LLVM type used to store all state associated with the current op.
+    }],
+    "llvm::Optional<LLVM::LLVMType>", "buildStateLLVMType">
+  ];
+}
+
+def DatasetNextOpInterface : OpInterface<"DatasetNext"> {
+  let description = [{
+    Properties of dataset next ops; used for lowering.
+  }];
+  let cppNamespace = "::mlir::NPCOMP::rd";
+
+  let methods = [
+    InterfaceMethod<[{
+      Returns the LLVM type used to store all state associated with the current op.
+    }],
+    "llvm::Optional<LLVM::LLVMType>", "buildStateLLVMType">
   ];
 }
 

--- a/include/npcomp/Dialect/RD/IR/RDOps.td
+++ b/include/npcomp/Dialect/RD/IR/RDOps.td
@@ -121,6 +121,13 @@ def RD_PipelineDefinitionOp : RD_Op<"pipeline_def", [IsolatedFromAbove, Symbol, 
     let regions = (region AnyRegion:$body);
 }
 
+def RD_IteratorIndexOp : RD_Op<"iterator_index"> {
+    let summary = "[Internal] Extracts the state for a nested iterator within this iterator.";
+
+    let arguments = (ins RD_Iterator:$parent, I64:$childIndex);
+    let results = (outs RD_Iterator:$result);
+}
+
 def RD_PipelineDefinitionTerminatorOp : RD_Op<"pipeline_def_terminator", [Terminator, HasParent<"PipelineDefinitionOp">]> {
     let summary = "A pseudo op that marks the end of a pipeline definition";
     let description = [{
@@ -154,7 +161,8 @@ multiclass RD_DatasetOp<
         string descriptionStr,
         dag datasetInputs,
         dag initInputs,
-        string assemblyFormatStr> {
+        string assemblyFormatStr,
+        string typeStr = "return {};"> {
     // The main op used to describe the input pipeline.
     def Op : RD_Op<mnemonic, [NoSideEffect, DeclareOpInterfaceMethods<DatasetTransformOpInterface>]> {
         let summary = summaryStr;
@@ -165,24 +173,36 @@ multiclass RD_DatasetOp<
     }
 
     // A related op to initialize iterator state.
-    def InitOp : RD_Op<!strconcat(mnemonic, ".init")> {
+    def InitOp : RD_Op<!strconcat(mnemonic, ".init"), [DatasetInitOpInterface]> {
         let summary = !strconcat("Initialize state for ", mnemonic);
         let arguments = !con(initInputs, (ins RD_Iterator:$state));
         // No results.
+
+        let extraClassDeclaration = !strconcat([{
+            llvm::Optional<LLVM::LLVMType> buildStateLLVMType() {
+        }], typeStr, [{
+            }
+        }]);
     }
 
     // A related op to advance the iterator state and return a result.
-    def NextOp : RD_Op<!strconcat(mnemonic, ".next")> {
+    def NextOp : RD_Op<!strconcat(mnemonic, ".next"), [DatasetNextOpInterface]> {
         let summary = !strconcat("Next func for ", mnemonic);
         let arguments = !con(datasetInputs, (ins RD_Iterator:$state));
         let results = (outs RD_Dataset:$result);
+
+        let extraClassDeclaration = !strconcat([{    llvm::Optional<LLVM::LLVMType> buildStateLLVMType() {
+        }], typeStr, [{    } }]);
     }
 }
 
 defm RD_Range : RD_DatasetOp<"range", "Range of values.", [{
         A sequence of consecutive integers.
     }], (ins ), (ins I64:$start, I64:$end, I64:$step),
-    "$start `to` $end `by` $step attr-dict `:` functional-type(operands, results)">;
+    "$start `to` $end `by` $step attr-dict `:` functional-type(operands, results)", [{
+        auto int64Ty = LLVM::LLVMType::getInt64Ty(getContext());
+        return LLVM::LLVMType::getStructTy(getContext(), {int64Ty, int64Ty, int64Ty});
+    }]>;
 
 defm RD_InlineMap : RD_DatasetOp<"inline_map", "Transform element values by applying function `f` to each of them.", [{
         A serial, sequential execution implementation of the elementwise application of

--- a/include/npcomp/Dialect/RD/IR/RDOps.td
+++ b/include/npcomp/Dialect/RD/IR/RDOps.td
@@ -124,8 +124,14 @@ def RD_PipelineDefinitionOp : RD_Op<"pipeline_def", [IsolatedFromAbove, Symbol, 
 def RD_IteratorIndexOp : RD_Op<"iterator_index"> {
     let summary = "[Internal] Extracts the state for a nested iterator within this iterator.";
 
-    let arguments = (ins RD_Iterator:$parent, I64:$childIndex);
+    let arguments = (ins RD_Iterator:$parent, I64ArrayAttr:$childIndex);
     let results = (outs RD_Iterator:$result);
+
+    let assemblyFormat = "$parent $childIndex attr-dict `:` type($result)";
+
+    let builders = [
+        OpBuilderDAG<(ins "::mlir::Value":$parent, "int64_t":$childIndex)>
+    ];
 }
 
 def RD_PipelineDefinitionTerminatorOp : RD_Op<"pipeline_def_terminator", [Terminator, HasParent<"PipelineDefinitionOp">]> {

--- a/include/npcomp/Dialect/RD/IR/RDOps.td
+++ b/include/npcomp/Dialect/RD/IR/RDOps.td
@@ -148,46 +148,52 @@ def RD_PrintOp : RD_Op<"print"> {
 
 // Dataset ops allow users to build up compositions of computations.
 
-class RD_DatasetOp<string mnemonic>
-    : RD_Op<mnemonic, [NoSideEffect, DeclareOpInterfaceMethods<DatasetTransformOpInterface>]> {
+multiclass RD_DatasetOp<
+        string mnemonic,
+        string summaryStr,
+        string descriptionStr,
+        dag datasetInputs,
+        dag initInputs,
+        string assemblyFormatStr> {
+    // The main op used to describe the input pipeline.
+    def Op : RD_Op<mnemonic, [NoSideEffect, DeclareOpInterfaceMethods<DatasetTransformOpInterface>]> {
+        let summary = summaryStr;
+        let description = descriptionStr;
+        let arguments = !con(datasetInputs, initInputs);
+        let results = (outs RD_Dataset:$result);
+        let assemblyFormat = assemblyFormatStr;
+    }
+
+    // A related op to initialize iterator state.
+    def InitOp : RD_Op<!strconcat(mnemonic, ".init")> {
+        let summary = !strconcat("Initialize state for ", mnemonic);
+        let arguments = !con(initInputs, (ins RD_Iterator:$state));
+        // No results.
+    }
+
+    // A related op to advance the iterator state and return a result.
+    def NextOp : RD_Op<!strconcat(mnemonic, ".next")> {
+        let summary = !strconcat("Next func for ", mnemonic);
+        let arguments = !con(datasetInputs, (ins RD_Iterator:$state));
+        let results = (outs RD_Dataset:$result);
+    }
 }
 
-def RD_RangeOp : RD_DatasetOp<"range"> {
-    let summary = "Range of values.";
-    let description = [{
+defm RD_Range : RD_DatasetOp<"range", "Range of values.", [{
         A sequence of consecutive integers.
-    }];
+    }], (ins ), (ins I64:$start, I64:$end, I64:$step),
+    "$start `to` $end `by` $step attr-dict `:` functional-type(operands, results)">;
 
-    let arguments = (ins I64:$start, I64:$end, I64:$step);
-    let results = (outs RD_Dataset:$result);
-
-    let assemblyFormat = "$start `to` $end `by` $step attr-dict `:` functional-type(operands, results)";
-}
-
-def RD_InlineMapOp : RD_DatasetOp<"inline_map"> {
-    let summary = "Transform element values by applying function `f` to each of them.";
-    let description = [{
+defm RD_InlineMap : RD_DatasetOp<"inline_map", "Transform element values by applying function `f` to each of them.", [{
         A serial, sequential execution implementation of the elementwise application of
         f to each of the elements in this dataset.
-    }];
+    }], (ins RD_Dataset:$src), (ins FlatSymbolRefAttr:$f),
+    "$f `(` $src `)` attr-dict `:` functional-type(operands, results)">;
 
-    let arguments = (ins RD_Dataset:$src, FlatSymbolRefAttr:$f);
-    let results = (outs RD_Dataset:$result);
-
-    let assemblyFormat = "$f `(` $src `)` attr-dict `:` functional-type(operands, results)";
-}
-
-def RD_FilterOp : RD_DatasetOp<"filter"> {
-    let summary = "Removes all values where `f` returns true.";
-    let description = [{
+defm RD_Filter : RD_DatasetOp<"filter", "Removes all values where `f` returns true.", [{
         A new dataset containing every element in `src` except for those
         that `f` of the element returns true.
-    }];
-
-    let arguments = (ins RD_Dataset:$src, FlatSymbolRefAttr:$f);
-    let results = (outs RD_Dataset:$result);
-
-    let assemblyFormat = "$src `excluding` $f attr-dict `:` functional-type(operands, results)";
-}
+    }], (ins RD_Dataset:$src), (ins FlatSymbolRefAttr:$f),
+    "$src `excluding` $f attr-dict `:` functional-type(operands, results)">;
 
 #endif // #ifndef RD_OPS

--- a/include/npcomp/Dialect/RD/Transforms/Passes.h
+++ b/include/npcomp/Dialect/RD/Transforms/Passes.h
@@ -20,6 +20,7 @@ namespace NPCOMP {
 std::unique_ptr<OperationPass<FuncOp>> createRDMergeFuncsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createExtractPipelineDefPass();
 std::unique_ptr<OperationPass<rd::PipelineDefinitionOp>> createBuildInitFuncPass();
+std::unique_ptr<OperationPass<rd::PipelineDefinitionOp>> createBuildNextFuncPass();
 
 /// Registers all RD transformation passes.
 void registerRDPasses();

--- a/include/npcomp/Dialect/RD/Transforms/Passes.td
+++ b/include/npcomp/Dialect/RD/Transforms/Passes.td
@@ -21,6 +21,11 @@ def RDBuildInitFunc : Pass<"rd-build-init-func", "::mlir::NPCOMP::rd::PipelineDe
   let constructor = "mlir::NPCOMP::createBuildInitFuncPass()";
 }
 
+def RDBuildNextFunc : Pass<"rd-build-next-func", "::mlir::NPCOMP::rd::PipelineDefinitionOp"> {
+  let summary = "Builds next funcs for a pipeline.";
+  let constructor = "mlir::NPCOMP::createBuildNextFuncPass()";
+}
+
 def RDMergeFuncs : Pass<"rd-mergefuncs", "FuncOp"> {
   let summary = "Merges functions in the rd dialect";
   let constructor = "mlir::NPCOMP::createRDMergeFuncsPass()";

--- a/lib/Dialect/RD/IR/RDOps.cpp
+++ b/lib/Dialect/RD/IR/RDOps.cpp
@@ -75,3 +75,9 @@ void InlineMapOp::buildNextOp(OpBuilder& builder, BlockAndValueMapping &mapping,
   auto ds = builder.create<InlineMapNextOp>(getLoc(), result().getType(), newSrc, state);
   mapping.map(getResult(), ds.getResult());
 }
+
+void IteratorIndexOp::build(::mlir::OpBuilder &odsBuilder,
+                  ::mlir::OperationState &odsState, ::mlir::Value parent,
+                  int64_t childIndex) {
+  IteratorIndexOp::build(odsBuilder, odsState, IteratorType::get(odsBuilder.getContext()), parent, odsBuilder.getI64ArrayAttr({childIndex}));
+}

--- a/lib/Dialect/RD/Transforms/BuildInitFuncPass.cpp
+++ b/lib/Dialect/RD/Transforms/BuildInitFuncPass.cpp
@@ -25,30 +25,11 @@
 using namespace mlir;
 using namespace mlir::NPCOMP;
 
-#include "npcomp/Dialect/RD/IR/RDDatasetInterface.cpp.inc"
-
 #define DEBUG_TYPE "rd-build-init-func"
 
 namespace {
 /// The ordered list of dataset operations that define a dataset.
 using PipelineDefinition = llvm::SmallVector<mlir::Operation*, 6>;
-
-llvm::Optional<FuncOp> findDefinitionFunc(rd::PipelineDefinitionOp definition) {
-  llvm::Optional<FuncOp> def;
-  definition.walk([&](FuncOp op) {
-    if (op.getName() == "definition") {
-      if (def) {
-        op.emitError("Multiple definition functions.").attachNote(def->getLoc()) << "Previous definition here.";
-        return;
-      }
-      def = op;
-    }
-  });
-  if (!def) {
-    definition.emitError("Missing definition function.");
-  }
-  return def;
-}
 
 /// The ordered list of dataset ops within the @definition func op.
 PipelineDefinition extractDatasetOps(FuncOp definition) {

--- a/lib/Dialect/RD/Transforms/BuildNextFuncPass.cpp
+++ b/lib/Dialect/RD/Transforms/BuildNextFuncPass.cpp
@@ -60,10 +60,11 @@ class BuildNextFunc : public RDBuildNextFuncBase<BuildNextFunc> {
     auto stateValue = nextBody->getArgument(0);
     BlockAndValueMapping mapping;
     builder.setInsertionPointToStart(nextBody);
+    int64_t offset = 0;
     defFunc.walk([&](Operation* op) {
       if (rd::DatasetTransform datasetOp = dyn_cast<rd::DatasetTransform>(op)) {
-        // TODO: Insert iterator index operation.
-        datasetOp.buildNextOp(builder, mapping, stateValue);
+        auto itrPtr = builder.create<rd::IteratorIndexOp>(op->getLoc(), stateValue, offset++);
+        datasetOp.buildNextOp(builder, mapping, itrPtr);
       }
       if (auto returnOp = dyn_cast<ReturnOp>(op)) {
         builder.clone(*returnOp.getOperation(), mapping);

--- a/lib/Dialect/RD/Transforms/BuildNextFuncPass.cpp
+++ b/lib/Dialect/RD/Transforms/BuildNextFuncPass.cpp
@@ -1,0 +1,78 @@
+//===- BuildInitFunc.cpp - Extracts a pipeline definition ---*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <set>
+
+#include "PassDetail.h"
+
+#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "npcomp/Dialect/RD/IR/RDDatasetInterface.h"
+#include "npcomp/Dialect/RD/IR/RDDialect.h"
+#include "npcomp/Dialect/RD/IR/RDOps.h"
+#include "npcomp/Dialect/RD/Transforms/Passes.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace mlir;
+using namespace mlir::NPCOMP;
+
+#define DEBUG_TYPE "rd-build-next-func"
+
+namespace {
+
+// Clones the definition function, transforming the ops used to the `[...].next` variations of the ops.
+class BuildNextFunc : public RDBuildNextFuncBase<BuildNextFunc> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<LLVM::LLVMDialect>();
+  }
+
+  void runOnOperation() override {
+    auto* context = &getContext();
+    auto pipelineDefOp = getOperation();
+    auto defFuncOpt = findDefinitionFunc(pipelineDefOp);
+    if (!defFuncOpt) {
+      return signalPassFailure();
+    }
+    auto defFunc = *defFuncOpt;
+
+    // Create the next func op.
+    auto nextFuncTy = FunctionType::get(
+      TypeRange(rd::IteratorType::get(context)),
+      TypeRange(defFunc.getType().getResult(0)),
+      context);
+
+    OpBuilder builder(context);
+    builder.setInsertionPointAfter(defFunc);
+    auto buildFuncOp = builder.create<FuncOp>(pipelineDefOp.getLoc(), "next", nextFuncTy);
+
+    // Fill in the body with a programmatic translation of the ops.
+    auto* nextBody = buildFuncOp.addEntryBlock();
+    auto stateValue = nextBody->getArgument(0);
+    BlockAndValueMapping mapping;
+    builder.setInsertionPointToStart(nextBody);
+    defFunc.walk([&](Operation* op) {
+      if (rd::DatasetTransform datasetOp = dyn_cast<rd::DatasetTransform>(op)) {
+        // TODO: Insert iterator index operation.
+        datasetOp.buildNextOp(builder, mapping, stateValue);
+      }
+      if (auto returnOp = dyn_cast<ReturnOp>(op)) {
+        builder.clone(*returnOp.getOperation(), mapping);
+      }
+    });
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<rd::PipelineDefinitionOp>> mlir::NPCOMP::createBuildNextFuncPass() {
+  return std::make_unique<BuildNextFunc>();
+}

--- a/lib/Dialect/RD/Transforms/CMakeLists.txt
+++ b/lib/Dialect/RD/Transforms/CMakeLists.txt
@@ -1,8 +1,10 @@
 add_npcomp_conversion_library(NPCOMPRDPasses
   BuildInitFuncPass.cpp
+  BuildNextFuncPass.cpp
   ExtractPipelineDef.cpp
   Passes.cpp
   MergeFuncs.cpp
+  RDDatasetInterface.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/npcomp/Dialect/RD/Transforms

--- a/lib/Dialect/RD/Transforms/PassDetail.h
+++ b/lib/Dialect/RD/Transforms/PassDetail.h
@@ -21,4 +21,11 @@ namespace NPCOMP {
 } // namespace NPCOMP
 } // end namespace mlir
 
+namespace mlir {
+namespace NPCOMP {
+// Returns the FuncOp that definesthe pipeline.
+llvm::Optional<FuncOp> findDefinitionFunc(rd::PipelineDefinitionOp definition);
+}
+}
+
 #endif // NPCOMP_DIALECT_RD_TRANSFORMS_PASSDETAIL_H

--- a/lib/Dialect/RD/Transforms/Passes.cpp
+++ b/lib/Dialect/RD/Transforms/Passes.cpp
@@ -18,3 +18,29 @@ namespace {
 } // end namespace
 
 void mlir::NPCOMP::registerRDPasses() { ::registerPasses(); }
+
+#include "PassDetail.h"
+
+namespace mlir {
+namespace NPCOMP {
+
+llvm::Optional<FuncOp> findDefinitionFunc(rd::PipelineDefinitionOp definition) {
+  llvm::Optional<FuncOp> def;
+  definition.walk([&](FuncOp op) {
+    if (op.getName() == "definition") {
+      if (def) {
+        op.emitError("Multiple definition functions.").attachNote(def->getLoc())
+            << "Previous definition here.";
+        return;
+      }
+      def = op;
+    }
+  });
+  if (!def) {
+    definition.emitError("Missing definition function.");
+  }
+  return def;
+}
+
+} // namespace NPCOMP
+} // namespace mlir

--- a/lib/Dialect/RD/Transforms/RDDatasetInterface.cpp
+++ b/lib/Dialect/RD/Transforms/RDDatasetInterface.cpp
@@ -1,0 +1,14 @@
+//===- BuildInitFunc.cpp - Extracts a pipeline definition ---*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "npcomp/Dialect/RD/IR/RDDatasetInterface.h"
+
+using namespace mlir;
+using namespace mlir::NPCOMP;
+
+#include "npcomp/Dialect/RD/IR/RDDatasetInterface.cpp.inc"

--- a/test/Dialect/RD/build_next_func.mlir
+++ b/test/Dialect/RD/build_next_func.mlir
@@ -1,0 +1,20 @@
+// RUN: npcomp-opt -rd-build-next-func %s | FileCheck --dump-input=fail %s
+
+// CHECK: rd.pipeline_def
+"rd.pipeline_def"() ( {
+  // CHECK: @definition
+  func @definition(%start: i64, %end: i64) -> !rd.Dataset {
+    %0 = rd.range %start to %end by %start : (i64, i64, i64) -> !rd.Dataset
+    %1 = rd.inline_map @double(%0) : (!rd.Dataset) -> !rd.Dataset
+    %2 = rd.filter %1 excluding @less_than_five : (!rd.Dataset) -> !rd.Dataset
+    return %2 : !rd.Dataset
+  }
+  // CHECK: func @next(%[[ITR:.*]]: !rd.Iterator) -> !rd.Dataset {
+  // CHECK: %[[RANGE_DS:.*]] = "rd.range.next"(%[[ITR]])
+  // CHECK: %[[MAP_DS:.*]] = "rd.inline_map.next"(%[[RANGE_DS]], %[[ITR]])
+  // CHECK: %[[FILTER_DS:.*]] = "rd.filter.next"(%[[MAP_DS]], %[[ITR]])
+  // CHECK: return %[[FILTER_DS]]
+  // CHECK: }
+  // CHECK: rd.pipeline_def_terminator
+  rd.pipeline_def_terminator
+}) { sym_name = "range_map_filter"} : () -> ()

--- a/test/Dialect/RD/build_next_func.mlir
+++ b/test/Dialect/RD/build_next_func.mlir
@@ -10,9 +10,12 @@
     return %2 : !rd.Dataset
   }
   // CHECK: func @next(%[[ITR:.*]]: !rd.Iterator) -> !rd.Dataset {
-  // CHECK: %[[RANGE_DS:.*]] = "rd.range.next"(%[[ITR]])
-  // CHECK: %[[MAP_DS:.*]] = "rd.inline_map.next"(%[[RANGE_DS]], %[[ITR]])
-  // CHECK: %[[FILTER_DS:.*]] = "rd.filter.next"(%[[MAP_DS]], %[[ITR]])
+  // CHECK: %[[RANGE_PTR:.*]] = rd.iterator_index %[[ITR]] [0]
+  // CHECK: %[[RANGE_DS:.*]] = "rd.range.next"(%[[RANGE_PTR]])
+  // CHECK: %[[MAP_PTR:.*]] = rd.iterator_index %[[ITR]] [1]
+  // CHECK: %[[MAP_DS:.*]] = "rd.inline_map.next"(%[[RANGE_DS]], %[[MAP_PTR]])
+  // CHECK: %[[FILTER_PTR:.*]] = rd.iterator_index %[[ITR]] [2]
+  // CHECK: %[[FILTER_DS:.*]] = "rd.filter.next"(%[[MAP_DS]], %[[FILTER_PTR]])
   // CHECK: return %[[FILTER_DS]]
   // CHECK: }
   // CHECK: rd.pipeline_def_terminator


### PR DESCRIPTION
The input program's dataset ops combine both initialization and dataflow
in a convenient form. To lower to iterator form, we need to tease apart
which parts are for initialization and which are used during actual iteration.

This change defines a `multiclass` that allows us to define 3 interrelated ops:
 1. The baseline op which is used to describe the input program.
 2. The init op, which initializes the iterator state.
 3. The next op, which advances the iterator by one and returns the next value.

The goal of defining these interrelated ops is to explore an implementation of
the lowerings to LLVM IR that is less monolithic (and thus easier to test and
develop) than the previous design.

Note: this change simply changes the tblgen, but has not yet defined appropriate
interfaces or generic passes to support this lowering.

Finally, I'm playihng fast-and-loose with the !rd.Dataset type, as it takes the
places of values (and boolean sentinals) in the `@next` functions, while
describing the aggregate computation / collection in the `@definition` func.